### PR TITLE
Swapped HTML anchor tag for material ui Link

### DIFF
--- a/sec.club/src/components/Header/Header.jsx
+++ b/sec.club/src/components/Header/Header.jsx
@@ -1,7 +1,8 @@
 import React from "react"
 import { makeStyles } from "@material-ui/core/styles"
 import { Container, Drawer, Button, IconButton, List, Typography, AppBar, Toolbar, SvgIcon, Hidden } from "@material-ui/core"
-import MenuIcon from '@material-ui/icons/Menu';
+import {Link as MaterialLink} from "@material-ui/core"
+import MenuIcon from '@material-ui/icons/Menu'
 import "./Header.scss"
 import { Link } from "react-router-dom"
 
@@ -86,7 +87,15 @@ const Header = () => {
             <MenuIcon />
           </IconButton>
         </Hidden>
-        <a href="/" className="barLogo">SEC</a>
+        <MaterialLink
+          className="barLogo"
+          component={Link}
+          to={'/'}
+          key={'menuItem-home'}
+          underline="none"
+        >
+          SEC
+        </MaterialLink>
         <Hidden smDown>
           <div className="header-items">
             {buttonRoutes.map((button, index) => (

--- a/sec.club/src/components/Header/Header.scss
+++ b/sec.club/src/components/Header/Header.scss
@@ -18,11 +18,10 @@
 
 .barLogo, .barLogo:visited, .barLogo:active {
     font-family: 'Source Code Pro', monospace;
-    font-size: 34px;
+    font-size: 40px;
     font-weight: bold;
     color:white;
     text-decoration: none currentColor solid;
-    margin-right: 10px;
 }
 
 .barLogo:hover{


### PR DESCRIPTION
Closes #41 

Swapped out the the `<a>` tag for a `<Link>` component from the Material UI in order to utilize the React router. The margin between the logo and the button to its right was not effected by the css for it in `Header.scss`, so I removed that line. I also increased the font size of the text to make it look more logo-like.