### PR TITLE
Expired events are hidden and easily adding many events

### DIFF
--- a/sec.club/src/components/EventBanner/EventBanner.jsx
+++ b/sec.club/src/components/EventBanner/EventBanner.jsx
@@ -4,7 +4,7 @@ import "./EventBanner.scss";
 export default function EventBanner({flyerSource, title, desc, endDate}) {
     let flyer = require(`../../assets/flyers/${flyerSource}`)
 
-    if (new Date().getTime() < endDate.getTime() || endDate === undefined) {
+    if (endDate === undefined || new Date().getTime() < endDate.getTime()) {
         return(
             <div className="flyer">
                 <div className="container">
@@ -17,6 +17,6 @@ export default function EventBanner({flyerSource, title, desc, endDate}) {
             </div>
         )
     } else {
-        return <div></div>
+        return null
     }
 }   

--- a/sec.club/src/components/EventBanner/EventBanner.jsx
+++ b/sec.club/src/components/EventBanner/EventBanner.jsx
@@ -1,18 +1,22 @@
 import React from "react";
 import "./EventBanner.scss";
 
-export default function EventBanner({flyerSource, title, desc}) {
+export default function EventBanner({flyerSource, title, desc, endDate}) {
     let flyer = require(`../../assets/flyers/${flyerSource}`)
 
-    return(
-        <div className="flyer">
-            <div className="container">
-                <img src={flyer.default} alt={`${flyerSource}`}/>
-                <div className="text-container">
-                    <span className="title">{title}</span>
-                    <span className="description">{desc}</span>
+    if (new Date().getTime() < endDate.getTime() || endDate === undefined) {
+        return(
+            <div className="flyer">
+                <div className="container">
+                    <img src={flyer.default} alt={`${flyerSource}`}/>
+                    <div className="text-container">
+                        <span className="title">{title}</span>
+                        <span className="description">{desc}</span>
+                    </div>
                 </div>
             </div>
-        </div>
-    )
-}
+        )
+    } else {
+        return <div></div>
+    }
+}   

--- a/sec.club/src/views/Home/Events.js
+++ b/sec.club/src/views/Home/Events.js
@@ -1,0 +1,21 @@
+/*
+Adding an event to the site:
+
+1. Upload a picture or flyer for the event and add it to /assets/flyers.
+2. Add an object to the EVENTS list of this format:
+    {
+        flyerSource: [name_of_uploaded_picture],
+        title: [name_of_event],
+        desc: [A brief description of the event],
+        endDate: new Date([the day the you want this event to stop showing on the home page])
+    }
+
+The endDate property is optional if you don't want an event to go away for a long time.
+
+*/
+
+const EVENTS = [
+    
+]
+
+export default EVENTS;

--- a/sec.club/src/views/Home/Home.js
+++ b/sec.club/src/views/Home/Home.js
@@ -6,6 +6,7 @@ import "../../assets/logo-hero.scss";
 import logo from "../../assets/logo.svg";
 import DocumentTitle from "../../components/DocumentTitle/DocumentTitle.js";
 import EventBanner from "../../components/EventBanner/EventBanner.jsx"
+import EVENTS from "./Events.js"
 
 export default function HomeView() {
 	return (
@@ -22,10 +23,15 @@ export default function HomeView() {
 				</Grid>
 			</Grid>
 			<Container className="banners">
-				<EventBanner
-					flyerSource="Pair Programming.png"
-					title="Pair Programming"
-					desc="Come out and learn about the Pair Programming paradigm just in time for Valentine's Day! Pizza will be served. Location: P 120"/>
+				{EVENTS.map((event) => {
+					return (
+						<EventBanner 
+						flyerSource={event.flyerSource}
+						title={event.title}
+						desc={event.desc}
+						endDate={event.endDate}/> 
+					)
+				})}
 			</Container>
 		</Box>
 	)


### PR DESCRIPTION
Inspired by a comment I left on my initial PR for EventBanners, the EventBanners now take in an optional prop called `endDate` that indicates when the event will stop being shown on the home page.

Inspired by @bsalgado98 's implementation of the slp-view, I moved all of the events into an array in their own file to make creating new events easier.