### PR TITLE
Focused style shares hover style

### DIFF
--- a/sec.club/src/components/Button/Button.scss
+++ b/sec.club/src/components/Button/Button.scss
@@ -14,8 +14,9 @@
 
 	transition: background-color .15s;
 
-	&:hover {
+	&:hover, &:focus{
 		background-color: lighten($background-color, 10%);
+		outline: none;
 	}
 
 	&.sec-kind-primary {


### PR DESCRIPTION
Closes #88 

The focused style is now should be the same as when you hover over a button. I haven't tested this on anything but Google Chrome though so we'll see how this goes.