### PR TITLE
Added missing route for setting default terminal

### DIFF
--- a/sec.club/src/Router.js
+++ b/sec.club/src/Router.js
@@ -99,6 +99,11 @@ const ROUTES = [
         Component: lazy(() => import(/* webpackChunkName: "article" */ "./views/Article/Article.js")),
     },
     {
+        path: "/tutorial/set-default-terminal",
+        articleProps: { source: "events/pimp-my-terminal/howto-set-default-terminal.md", title: "How to set your default terminal"},
+        Component: lazy(() => import(/* webpackChunkName: "article" */ "./views/Article/Article.js")),
+    },
+    {
         path: "*",
         Component: lazy(() => import(/* webpackChunkName: "not-found" */"./views/NotFound/NotFound.jsx")),
     },

--- a/sec.club/src/components/Header/Header.jsx
+++ b/sec.club/src/components/Header/Header.jsx
@@ -56,6 +56,12 @@ const Header = () => {
       route: "/contact"
     }
   ]
+  const moreRoutes = [
+    {
+      title: "Pimp My Terminal",
+      route: "/event/pimp-my-terminal"
+    }
+  ]
   const sideList = side => (
     <div
       className={classes.list}
@@ -70,6 +76,16 @@ const Header = () => {
             kind="menu"
             to={button.route}
             key={`menuItem-${index}`}
+          >
+            {button.title}
+          </Button>
+        ))}
+        {moreRoutes.map((button, index) => (
+          <Button
+            className="drawer-item"
+            kind="menu"
+            to={button.route}
+            key={`menuItem-${index + buttonRoutes.length}`}
           >
             {button.title}
           </Button>


### PR DESCRIPTION
Closes #120 

Pimp My Terminal was not loading because the route /tutorial/set-default-terminal was missed during the change from having moving the routes from `App.js` to `Router.js`. After #109 was merged, routes referenced in articles that do not exist will cause React to throw an error.

I also added Pimp My Terminal to the More drawer in the header so that members who could not make it can still easily reference it.