### PR TITLE
Links to other routes in articles work properly again

### DIFF
--- a/sec.club/src/views/Article/Article.js
+++ b/sec.club/src/views/Article/Article.js
@@ -79,11 +79,9 @@ export default class ArticleView extends PureComponent {
 				throw new InvalidRouteError(`The route ${href} does not exist.`);
 			}
 			return (
-				<Router>
-					<Link to={href}>
-						{children}
-					</Link>
-				</Router>
+				<Link to={href}>
+					{children}
+				</Link>
 			);
 		} else {
 			return (

--- a/sec.club/src/views/Article/Article.js
+++ b/sec.club/src/views/Article/Article.js
@@ -7,7 +7,7 @@ import HtmlParser from "react-markdown/plugins/html-parser";
 import Loader from "../../components/Loader/Loader.js";
 import CodeBlock from "../../components/CodeBlock/CodeBlock.js";
 import DocumentTitle from "../../components/DocumentTitle/DocumentTitle.js";
-import { BrowserRouter as Router, Link } from "react-router-dom";
+import { Link } from "react-router-dom";
 import ROUTES from "../../Router";
 
 // See https://github.com/aknuds1/html-to-react#with-custom-processing-instructions

--- a/sec.club/src/views/Article/Article.test.js
+++ b/sec.club/src/views/Article/Article.test.js
@@ -3,6 +3,7 @@ import { render, unmountComponentAtNode } from "react-dom";
 import { act } from "react-dom/test-utils";
 import { getByTestId, queryByTestId } from "@testing-library/dom";
 import "@testing-library/jest-dom";
+import {BrowserRouter as Router} from 'react-router-dom'
 
 import ArticleView from './Article.js';
 
@@ -131,7 +132,7 @@ describe('ArticleView', () => {
 		fetch.mockResponse(() => Promise.resolve(markdown))
 		
 		await act(async () => {
-			render(<ArticleView source="README.md" title="Valid Routes" />, container);
+			render(<Router><ArticleView source="README.md" title="Valid Routes" /></Router>, container);
 		});
 
 		expect(container).toContainHTML('<h1>Valid Routes</h1>');


### PR DESCRIPTION
Closes #122 

The `Router` component that was being returned by `buildLink` in `Article.js` was the source of the bug, that function needs to return `Link`s, not `Router`s. 

I updated a test to include a `Router`, since `Link`s are required to be children of a `Router`. 