### PR TITLE
Slide deck for presentations

### DIFF
--- a/sec.club/src/Router.js
+++ b/sec.club/src/Router.js
@@ -45,6 +45,10 @@ const ROUTES = [
         Component: lazy(() => import(/* webpackChunkName: "demo" */ "./views/ComponentsDemo/ComponentsDemo.js")),
     },
     {
+        path: "/dev/slide_deck",
+        Component: lazy(() => import(/* webpackChunkName: "slide_deck_demo" */ "./views/SlideDeckDemo/SlideDeckDemo.js")),
+    },
+    {
         path: "/event/pair-programming-2020",
         articleProps: { source: "event/2020-pair-programming.md", title: "Pair Programming 2020",},
         Component: lazy(() => import(/* webpackChunkName: "article" */ "./views/Article/Article.js"))

--- a/sec.club/src/components/SlideDeck/SlideDeck.js
+++ b/sec.club/src/components/SlideDeck/SlideDeck.js
@@ -12,65 +12,30 @@ class Slide extends React.Component {
     }
 }
 
+class InvalidChildComponentError extends TypeError {}
+
 class SlideDeck extends React.Component {
+
     constructor(props){
         super(props);
-        this.state = {currentSlide: -1};
+        this.state = {currentSlide: 0};
 
-        //find the first slide child element if elem 0 is not a Slide
-        if(!this.isTypeSlide(this.state.currentSlide)){
-            this.state = {currentSlide: this.findNextSlide()}
-        }
+        this.props.children.forEach(child => {
+            if(child.type.name !== "Slide"){
+                throw new InvalidChildComponentError(`All children of SlideDeck must be Slide components.);
+            }
+        })
 
         this.handleClick = this.handleClick.bind(this);
         this.handleOnContext = this.handleOnContext.bind(this);
     }
 
-    isInbounds = (index) => {
-        return index >= 0 && index <= this.props.children.length - 1;
-    }
-
-    isTypeSlide = (index) => {
-        return this.isInbounds(index) && this.props.children[index].type.name === "Slide";
-    }
-
-    isFirstChild = (index) => {
-        return index === 0;
-    }
-
-    isLastChild = (index) => {
-        return index === this.props.children.length - 1;
-    }
-
-    findNextSlide = () => {
-        let next = this.state.currentSlide + 1;
-
-        while(!this.isTypeSlide(next) && !this.isLastChild(next)){
-            next++;
-        }
-        return next;
-    }
-
     nextSlide() {
-        if (this.isLastChild(this.state.currentSlide)){
-            return;
-        }
-        let next = this.findNextSlide();
-        this.setState({currentSlide: next})
+        this.setState({currentSlide: this.state.currentSlide + 1})
     }
 
     prevSlide(){
-        if (this.isFirstChild(this.state.currentSlide)){
-            return;
-        }
-
-        let prev = this.state.currentSlide - 1;
-
-        while(!this.isTypeSlide(prev) && !this.isFirstChild(prev)){
-            prev--;
-        }
-
-        this.setState({currentSlide: prev})
+        this.setState({currentSlide: this.state.currentSlide - 1})
     }
 
 

--- a/sec.club/src/components/SlideDeck/SlideDeck.js
+++ b/sec.club/src/components/SlideDeck/SlideDeck.js
@@ -22,7 +22,7 @@ class SlideDeck extends React.Component {
 
         this.props.children.forEach(child => {
             if(child.type.name !== "Slide"){
-                throw new InvalidChildComponentError(`All children of SlideDeck must be Slide components.);
+                throw new InvalidChildComponentError("All children of SlideDeck must be Slide components.");
             }
         })
 

--- a/sec.club/src/components/SlideDeck/SlideDeck.js
+++ b/sec.club/src/components/SlideDeck/SlideDeck.js
@@ -1,0 +1,26 @@
+import React from "react";
+import { Container } from "@material-ui/core";
+
+class Slide extends React.Component {
+    constructor(props){
+        super(props);
+        this.props = props;
+    }
+    render() {
+        return <Container>{this.props.children}</Container>;
+    }
+}
+
+class SlideDeck extends React.Component {
+    constructor(props){
+        super(props);
+        this.state = {currentSlide: props.children[0], prevSlide: null, nextSlide: null};
+        //assume there are some n Slides as children for now
+    }
+
+    render() {
+        return this.state.currentSlide;
+    }
+}
+
+export {SlideDeck, Slide}

--- a/sec.club/src/components/SlideDeck/SlideDeck.js
+++ b/sec.club/src/components/SlideDeck/SlideDeck.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { Container } from "@material-ui/core";
+import "./SlideDeck.scss";
 
 class Slide extends React.Component {
     constructor(props){
@@ -7,19 +8,54 @@ class Slide extends React.Component {
         this.props = props;
     }
     render() {
-        return <Container>{this.props.children}</Container>;
+        return <Container className="slide">{this.props.children}</Container>;
     }
 }
 
 class SlideDeck extends React.Component {
     constructor(props){
         super(props);
-        this.state = {currentSlide: props.children[0], prevSlide: null, nextSlide: null};
-        //assume there are some n Slides as children for now
+        this.state = {currentSlide: 0};
+        this.handleClick = this.handleClick.bind(this);
+    }
+
+    nextSlide() {
+        let isInbounds = (index) => {
+            return index > 0 && index <= this.props.children.length - 1;
+        }
+
+        let isTypeSlide = (index) => {
+            return isInbounds(index) && this.props.children[index].type.name === "Slide";
+        }
+
+       let isLastChild = (index) => {
+            return index === this.props.children.length - 1;
+        }
+
+        if (isLastChild(this.state.currentSlide)){
+            return;
+        }
+
+        let next = this.state.currentSlide + 1;
+
+        while(!isTypeSlide(next) && !isLastChild(next)){
+            next++;
+        }
+
+        this.setState({currentSlide: next})
+    }
+
+
+    handleClick() {
+        this.nextSlide();
     }
 
     render() {
-        return this.state.currentSlide;
+        return (
+            <div onClick={this.handleClick}>
+            {this.props.children[this.state.currentSlide]}
+            </div>
+        );
     }
 }
 

--- a/sec.club/src/components/SlideDeck/SlideDeck.js
+++ b/sec.club/src/components/SlideDeck/SlideDeck.js
@@ -15,34 +15,62 @@ class Slide extends React.Component {
 class SlideDeck extends React.Component {
     constructor(props){
         super(props);
-        this.state = {currentSlide: 0};
+        this.state = {currentSlide: -1};
+
+        //find the first slide child element if elem 0 is not a Slide
+        if(!this.isTypeSlide(this.state.currentSlide)){
+            this.state = {currentSlide: this.findNextSlide()}
+        }
+
         this.handleClick = this.handleClick.bind(this);
+        this.handleOnContext = this.handleOnContext.bind(this);
+    }
+
+    isInbounds = (index) => {
+        return index >= 0 && index <= this.props.children.length - 1;
+    }
+
+    isTypeSlide = (index) => {
+        return this.isInbounds(index) && this.props.children[index].type.name === "Slide";
+    }
+
+    isFirstChild = (index) => {
+        return index === 0;
+    }
+
+    isLastChild = (index) => {
+        return index === this.props.children.length - 1;
+    }
+
+    findNextSlide = () => {
+        let next = this.state.currentSlide + 1;
+
+        while(!this.isTypeSlide(next) && !this.isLastChild(next)){
+            next++;
+        }
+        return next;
     }
 
     nextSlide() {
-        let isInbounds = (index) => {
-            return index > 0 && index <= this.props.children.length - 1;
+        if (this.isLastChild(this.state.currentSlide)){
+            return;
         }
+        let next = this.findNextSlide();
+        this.setState({currentSlide: next})
+    }
 
-        let isTypeSlide = (index) => {
-            return isInbounds(index) && this.props.children[index].type.name === "Slide";
-        }
-
-       let isLastChild = (index) => {
-            return index === this.props.children.length - 1;
-        }
-
-        if (isLastChild(this.state.currentSlide)){
+    prevSlide(){
+        if (this.isFirstChild(this.state.currentSlide)){
             return;
         }
 
-        let next = this.state.currentSlide + 1;
+        let prev = this.state.currentSlide - 1;
 
-        while(!isTypeSlide(next) && !isLastChild(next)){
-            next++;
+        while(!this.isTypeSlide(prev) && !this.isFirstChild(prev)){
+            prev--;
         }
 
-        this.setState({currentSlide: next})
+        this.setState({currentSlide: prev})
     }
 
 
@@ -50,9 +78,14 @@ class SlideDeck extends React.Component {
         this.nextSlide();
     }
 
+    handleOnContext(e){
+        e.preventDefault();
+        this.prevSlide();
+    }
+
     render() {
         return (
-            <div onClick={this.handleClick}>
+            <div onClick={this.handleClick} onContextMenu={this.handleOnContext}>
             {this.props.children[this.state.currentSlide]}
             </div>
         );

--- a/sec.club/src/components/SlideDeck/SlideDeck.scss
+++ b/sec.club/src/components/SlideDeck/SlideDeck.scss
@@ -1,0 +1,8 @@
+@import "../../variables.scss"; 
+
+.slide {
+    display: flex;
+    margin: 10px;
+    height: 90vh;
+    border: 1px solid $primary-color;
+}

--- a/sec.club/src/views/SlideDeckDemo/SlideDeckDemo.js
+++ b/sec.club/src/views/SlideDeckDemo/SlideDeckDemo.js
@@ -7,14 +7,16 @@ class SlideDeckDemo extends React.Component {
         return(
         <Container>
             <SlideDeck>
+                <h1>I dont belong at the beginning</h1>
                 <Slide>
                     <h1>Slide 1</h1>
                 </Slide>
                 <Slide>
                     <h1>Slide 2</h1>
                 </Slide>
+                <h1>I'm not a slide??!! I guess I'll be skipped...</h1>
                 <Slide>
-                    <h1>Slide 3</h1>
+                    <h1>Slide 3 (But Child 5!)</h1>
                 </Slide>
             </SlideDeck>
         </Container>

--- a/sec.club/src/views/SlideDeckDemo/SlideDeckDemo.js
+++ b/sec.club/src/views/SlideDeckDemo/SlideDeckDemo.js
@@ -7,16 +7,14 @@ class SlideDeckDemo extends React.Component {
         return(
         <Container>
             <SlideDeck>
-                <h1>I dont belong at the beginning</h1>
                 <Slide>
                     <h1>Slide 1</h1>
                 </Slide>
                 <Slide>
                     <h1>Slide 2</h1>
                 </Slide>
-                <h1>I'm not a slide??!! I guess I'll be skipped...</h1>
                 <Slide>
-                    <h1>Slide 3 (But Child 5!)</h1>
+                    <h1>Slide 3</h1>
                 </Slide>
             </SlideDeck>
         </Container>

--- a/sec.club/src/views/SlideDeckDemo/SlideDeckDemo.js
+++ b/sec.club/src/views/SlideDeckDemo/SlideDeckDemo.js
@@ -10,8 +10,11 @@ class SlideDeckDemo extends React.Component {
                 <Slide>
                     <h1>Slide 1</h1>
                 </Slide>
-                    <h1>Slide 2</h1>
                 <Slide>
+                    <h1>Slide 2</h1>
+                </Slide>
+                <Slide>
+                    <h1>Slide 3</h1>
                 </Slide>
             </SlideDeck>
         </Container>

--- a/sec.club/src/views/SlideDeckDemo/SlideDeckDemo.js
+++ b/sec.club/src/views/SlideDeckDemo/SlideDeckDemo.js
@@ -1,0 +1,23 @@
+import React from "react";
+import { Container } from "@material-ui/core";
+import {Slide, SlideDeck} from "../../components/SlideDeck/SlideDeck.js";
+
+class SlideDeckDemo extends React.Component {
+    render(){
+        return(
+        <Container>
+            <SlideDeck>
+                <Slide>
+                    <h1>Slide 1</h1>
+                </Slide>
+                    <h1>Slide 2</h1>
+                <Slide>
+                </Slide>
+            </SlideDeck>
+        </Container>
+        )
+    }
+}
+
+export default SlideDeckDemo;
+


### PR DESCRIPTION
Fixes issue #140 
Progress on the prototype so far:

- Introduces a `SlideDeck` component that holds new `Slide` components.
- Each `Slide` can hold some JSX children that will be rendered (and can likely support the markdown components with a few tweaks!)
- A red border is around each slide. The slide takes up most of the page.
- The slides can be navigated between using left and right click (or short and long presses on mobile).

![image](https://user-images.githubusercontent.com/21251320/91621555-60010300-e961-11ea-8d0f-f67218b413f9.png)

