### PR TITLE
Header and footer should not be visible on slide deck pages

### DIFF
--- a/sec.club/src/App.js
+++ b/sec.club/src/App.js
@@ -6,6 +6,7 @@ import { red, cyan } from "@material-ui/core/colors"
 import Loader from "./components/Loader/Loader.js"
 import ErrorBoundaryLoader from "./components/Loader/ErrorBoundaryLoader.js"
 import ROUTES from "./Router.js"
+import { DefaultLayout, SlideDeckLayout } from "./layouts.js"
 
 import SecStyle from "./variables.scss"
 
@@ -21,8 +22,9 @@ const Footer = lazy(() => import(/* webpackChunkName: "components" */"./componen
 //   .then(([moduleExports]) => moduleExports);
 // });
 
-function App() {
-  const theme = createMuiTheme({
+function App(){
+
+const theme = createMuiTheme({
     palette: {
       type: "dark",
       primary: red,
@@ -40,38 +42,33 @@ function App() {
       quaternary: "white"
     }
   })
+
   return (
     <Router>
       <ThemeProvider theme={theme}>
         <div className="App">
         <Suspense fallback={<div>Loading...</div>}>
-          <ErrorBoundaryLoader>
-            <Header></Header>
-          </ErrorBoundaryLoader>
           <Suspense fallback={<Loader/>}>
           <ErrorBoundaryLoader>
             <div className="content-wrap">
               <Switch>
               <Redirect from="/pmt" to="/event/pimp-my-terminal" />
-                {ROUTES.map(({ path, Component, articleProps }, index) => {
+                {ROUTES.map(({ path, Component, articleProps, isPresentation }, index) => {
                   if (path === "/") { //Root view
                     return (
                       <Route exact path={path} key={"route-" + index}>
-                        <Component/>
+                        <Header/>
+                        <Suspense fallback={<Loader/>}>
+                            <Component/>
+                        </Suspense>
                       </Route>
                     )
                   } else if (articleProps){ //Article views
-                    return(
-                      <Route path={path} key={"route-" + index}>
-                        <Component {...articleProps}/>
-                      </Route>
-                    );
+                    return <DefaultLayout path={path} key={"route-" + index} component={<Component {...articleProps}/>}/>
+                  } else if (isPresentation){
+                    return <SlideDeckLayout path={path} key={"route-" + index} component={<Component/>}/>
                   } else { //Other views
-                    return (
-                      <Route path={path} key={"route-" + index}>
-                        <Component/>
-                      </Route>
-                    )
+                    return <DefaultLayout path={path} key={"route-" + index} component={<Component/>}/>
                   }
                 })}
               </Switch>

--- a/sec.club/src/Router.js
+++ b/sec.club/src/Router.js
@@ -54,6 +54,7 @@ const ROUTES = [
     },
     {
         path: "/dev/slide_deck",
+        isPresentation: true,
         Component: lazy(() => import(/* webpackChunkName: "demo" */ "./views/SlideDeckDemo/SlideDeckDemo.js")),
     },
     {

--- a/sec.club/src/components/SlideDeck/SlideDeck.scss
+++ b/sec.club/src/components/SlideDeck/SlideDeck.scss
@@ -3,6 +3,6 @@
 .slide {
     display: flex;
     margin: 10px;
-    height: 90vh;
+    height: 98vh;
     border: 1px solid $primary-color;
 }

--- a/sec.club/src/layouts.js
+++ b/sec.club/src/layouts.js
@@ -1,0 +1,33 @@
+import React, { lazy, Suspense } from "react";
+import { Route } from "react-router-dom";
+import Loader from "./components/Loader/Loader.js";
+
+const Header = lazy(() => import(/* webackChunkName: "components" */"./components/Header/Header"));
+const Footer = lazy(() => import(/* webackChunkName: "components" */"./components/Footer/Footer"));
+
+class DefaultLayout extends React.Component {
+    render(){
+        return(
+        <Route path={this.props.path} key={this.props.key}>
+            <Header/>
+                <Suspense fallback={<Loader/>}>
+                    {this.props.component}
+                </Suspense>
+        </Route>
+        )
+    }
+}
+
+class SlideDeckLayout extends React.Component {
+     render(){
+        return(
+        <Route path={this.props.path} key={this.props.key}>
+            <Suspense fallback={<Loader/>}>
+                {this.props.component}
+            </Suspense>
+        </Route>
+        )
+    }
+}
+
+export { DefaultLayout, SlideDeckLayout };

--- a/sec.club/src/layouts.js
+++ b/sec.club/src/layouts.js
@@ -3,7 +3,7 @@ import { Route } from "react-router-dom";
 import Loader from "./components/Loader/Loader.js";
 
 const Header = lazy(() => import(/* webackChunkName: "components" */"./components/Header/Header"));
-const Footer = lazy(() => import(/* webackChunkName: "components" */"./components/Footer/Footer"));
+//const Footer = lazy(() => import(/* webackChunkName: "components" */"./components/Footer/Footer"));
 
 class DefaultLayout extends React.Component {
     render(){


### PR DESCRIPTION
Fixes #147

Progress so far: Layout components are introduced for certain routes to use. If a route is indicated in the router as being a presentation, the header is hidden. The next step for the header is to have it slide out from the top of the page if the user hovers their mouse there for some time, so that the user can navigate away from the slides. Another potential solution is for a back arrow button to be placed to the left of the slides that takes the user back to the last route they visited on the site, or the home page if they had not yet navigated to any other page.

The footer is trickier to move. If its moved into the Layout components, then an old bug resurfaces where the footer is rendered before the rest of the page and the page is visibly messed up for a half second. But if the footer is left in `App`, then it becomes more difficult to control it showing up conditionally based on the current route and the `isPresentation`  indicator in the router. Any thoughts? 