### PR TITLE
Implemented slide deck controls

### DIFF
--- a/src/components/SlideDeck/SlideDeck.js
+++ b/src/components/SlideDeck/SlideDeck.js
@@ -88,6 +88,12 @@ class SlideDeck extends React.Component {
         isFullscreen: false,
       });
     }
+    if (e.key === 'ArrowLeft') {
+      this.prevSlide();
+    }
+    if (e.key === 'ArrowRight') {
+      this.nextSlide();
+    }
   }
 
   nextSlide() {

--- a/src/components/SlideDeck/SlideDeck.js
+++ b/src/components/SlideDeck/SlideDeck.js
@@ -88,11 +88,9 @@ class SlideDeck extends React.Component {
             this.setState({
                 isFullscreen: false,
             });
-        }
-        if (e.key === "ArrowLeft") {
+        } else if (e.key === "ArrowLeft") {
             this.prevSlide();
-        }
-        if (e.key === "ArrowRight") {
+        } else if (e.key === "ArrowRight") {
             this.nextSlide();
         }
     }

--- a/src/components/SlideDeck/SlideDeck.js
+++ b/src/components/SlideDeck/SlideDeck.js
@@ -1,235 +1,245 @@
-import React from 'react';
-import PropTypes from 'prop-types';
+import React from "react";
+import PropTypes from "prop-types";
 import {
-  Container,
-  Divider,
-  InputLabel,
-  MenuItem,
-  Select,
-  LinearProgress,
-} from '@material-ui/core';
-import './SlideDeck.scss';
-import { UxContext } from '../../contexts.js';
+    Container,
+    Divider,
+    InputLabel,
+    MenuItem,
+    Select,
+    LinearProgress,
+} from "@material-ui/core";
+import "./SlideDeck.scss";
+import { UxContext } from "../../contexts.js";
 import {
-  Fullscreen,
-  KeyboardArrowLeft,
-  KeyboardArrowRight,
-} from '@material-ui/icons';
+    Fullscreen,
+    KeyboardArrowLeft,
+    KeyboardArrowRight,
+} from "@material-ui/icons";
 
 class Slide extends React.Component {
-  static propTypes = {
-    sticky: PropTypes.bool,
-    stickyUntil: PropTypes.number,
-  };
-
-  constructor(props) {
-    super(props);
-    this.props = props;
-  }
-  render() {
-    return (
-      <Container className={`slide-content ${this.props.className}`}>
-        {this.props.children}
-      </Container>
-    );
-  }
-}
-
-class InvalidChildComponentError extends TypeError {}
-
-class SlideDeck extends React.Component {
-  static contextType = UxContext;
-
-  constructor(props) {
-    super(props);
-    this.state = {
-      currentSlide: 0,
-      isFullscreen: false,
-      stickied: {
-        current: null,
-        previous: [],
-      },
+    static propTypes = {
+        sticky: PropTypes.bool,
+        stickyUntil: PropTypes.number,
     };
 
-    this.props.children.forEach((child) => {
-      if (
-        child.type.name !== 'Slide' &&
-        process.env.NODE_ENV !== 'production'
-      ) {
-        throw new InvalidChildComponentError(
-          `All children of SlideDeck must be Slide components. Got "${child.type.name}" instead`
+    constructor(props) {
+        super(props);
+        this.props = props;
+    }
+    render() {
+        return (
+            <Container className={`slide-content ${this.props.className}`}>
+                {this.props.children}
+            </Container>
         );
-      }
-    });
-
-    this.nextSlide = this.nextSlide.bind(this);
-    this.prevSlide = this.prevSlide.bind(this);
-    this.handleSlideChange = this.handleSlideChange.bind(this);
-    this.handleKeyPress = this.handleKeyPress.bind(this);
-  }
-
-  componentDidMount() {
-    document.addEventListener('keydown', this.handleKeyPress, false);
-  }
-
-  componentWillUnmount() {
-    document.removeEventListener('keydown', this.handleKeyPress, false);
-  }
-
-  handleSlideChange(e) {
-    this.setState({
-      currentSlide: e.target.value,
-    });
-  }
-
-  handleKeyPress(e) {
-    if (e.key === 'Escape') {
-      this.setState({
-        isFullscreen: false,
-      });
     }
-    if (e.key === 'ArrowLeft') {
-      this.prevSlide();
-    }
-    if (e.key === 'ArrowRight') {
-      this.nextSlide();
-    }
-  }
+}
 
-  nextSlide() {
-    let next = this.state.currentSlide + 1;
-    if (next > this.props.children.length - 1) {
-      return;
-    }
-    let newstate = { currentSlide: next };
-    if (this.props.children[this.state.currentSlide].props.sticky) {
-      let previousStickies = this.state.stickied.previous;
-      if (this.state.stickied.current) {
-        previousStickies.push(this.state.stickied.current);
-      }
-      newstate.stickied = {
-        current: this.state.currentSlide,
-        previous: previousStickies,
-      };
-    } else if (
-      this.state.stickied.current &&
-      newstate.currentSlide >=
-        this.props.children[this.state.stickied.current].props.stickyUntil
-    ) {
-      let previousStickies = this.state.stickied.previous;
-      previousStickies.push(this.state.stickied.current);
-      newstate.stickied = {
-        current: null,
-        previous: previousStickies,
-      };
-    }
-    this.setState(newstate);
-  }
+class InvalidChildComponentError extends TypeError { }
 
-  prevSlide() {
-    let prev = this.state.currentSlide - 1;
-    if (prev < 0) {
-      return;
-    }
-    let newstate = { currentSlide: prev };
-    if (prev === this.state.stickied.current) {
-      let previousStickies = this.state.stickied.previous;
-      newstate.stickied = {
-        current: previousStickies.length > 0 ? previousStickies.pop() : null,
-        previous: previousStickies,
-      };
-    }
-    this.setState(newstate);
-  }
+class SlideDeck extends React.Component {
+    static contextType = UxContext;
 
-  setFullscreen(s) {
-    this.setState({
-      isFullscreen: s,
-    });
-  }
+    constructor(props) {
+        super(props);
+        this.state = {
+            currentSlide: 0,
+            isFullscreen: false,
+            stickied: {
+                current: null,
+                previous: [],
+            },
+        };
 
-  slideProgress() {
-    let numSlides = this.props.children.length - 1;
-    if (numSlides < 2) {
-      return 100;
-    }
-    return (this.state.currentSlide / numSlides) * 100;
-  }
+        this.props.children.forEach((child) => {
+            if (
+                child.type.name !== "Slide" &&
+                process.env.NODE_ENV !== "production"
+            ) {
+                throw new InvalidChildComponentError(
+                    `All children of SlideDeck must be Slide components. Got "${child.type.name}" instead`
+                );
+            }
+        });
 
-  render() {
-    this.context.headerCompact = true;
-    this.context.footerVisible = false;
-    let elements = [];
-    if (this.state.stickied.current) {
-      elements.push(
-        <div className="slide sticky" key="sticky">
-          {this.props.children[this.state.stickied.current]}
-        </div>
-      );
+        this.nextSlide = this.nextSlide.bind(this);
+        this.prevSlide = this.prevSlide.bind(this);
+        this.handleSlideChange = this.handleSlideChange.bind(this);
+        this.handleKeyPress = this.handleKeyPress.bind(this);
     }
-    elements.push(
-      <div
-        className={`slide primary ${
-          this.state.stickied.current ? 'sticky-is-present' : ''
-        }`}
-        key="currentSlide"
-      >
-        {this.props.children[this.state.currentSlide]}
-      </div>
-    );
-    let progress = this.slideProgress();
-    let slideSelect = [];
-    for (let i = 0; i < this.props.children.length; i++) {
-      slideSelect.push(
-        <MenuItem key={i} value={i}>{`Slide ${i + 1}`}</MenuItem>
-      );
+
+    componentDidMount() {
+        document.addEventListener("keydown", this.handleKeyPress, false);
     }
-    let fullscreenClass = this.state.isFullscreen
-      ? 'slide-deck-fullscreen'
-      : '';
-    return (
-      <div className={`slide-deck ${fullscreenClass}`}>
-        {elements}
-        <Container className={`slide-deck-controls ${fullscreenClass}`}>
-          <div className="control-slide">
-            <KeyboardArrowLeft
-              className="slide-deck-control-btn"
-              onClick={this.prevSlide}
-            ></KeyboardArrowLeft>
-            <KeyboardArrowRight
-              className="slide-deck-control-btn"
-              onClick={this.nextSlide}
-            ></KeyboardArrowRight>
-            <InputLabel id="slide-deck-selector"></InputLabel>
-            <Select
-              className="slide-deck-selector"
-              labelId="slide-deck-selector"
-              value={this.state.currentSlide}
-              onChange={this.handleSlideChange}
+
+    componentWillUnmount() {
+        document.removeEventListener("keydown", this.handleKeyPress, false);
+    }
+
+    handleSlideChange(e) {
+        e.stopPropagation();
+        this.setState({
+            currentSlide: e.target.value,
+        });
+    }
+
+    handleKeyPress(e) {
+        if (e.key === "Escape") {
+            this.setState({
+                isFullscreen: false,
+            });
+        }
+        if (e.key === "ArrowLeft") {
+            this.prevSlide();
+        }
+        if (e.key === "ArrowRight") {
+            this.nextSlide();
+        }
+    }
+
+    nextSlide(e) {
+        e.stopPropagation();
+        let next = this.state.currentSlide + 1;
+        if (next > this.props.children.length - 1) {
+            return;
+        }
+        let newstate = { currentSlide: next };
+        if (this.props.children[this.state.currentSlide].props.sticky) {
+            let previousStickies = this.state.stickied.previous;
+            if (this.state.stickied.current) {
+                previousStickies.push(this.state.stickied.current);
+            }
+            newstate.stickied = {
+                current: this.state.currentSlide,
+                previous: previousStickies,
+            };
+        } else if (
+            this.state.stickied.current &&
+            newstate.currentSlide >=
+            this.props.children[this.state.stickied.current].props.stickyUntil
+        ) {
+            let previousStickies = this.state.stickied.previous;
+            previousStickies.push(this.state.stickied.current);
+            newstate.stickied = {
+                current: null,
+                previous: previousStickies,
+            };
+        }
+        this.setState(newstate);
+    }
+
+    prevSlide(e) {
+        e.stopPropagation();
+        let prev = this.state.currentSlide - 1;
+        if (prev < 0) {
+            return;
+        }
+        let newstate = { currentSlide: prev };
+        if (prev === this.state.stickied.current) {
+            let previousStickies = this.state.stickied.previous;
+            newstate.stickied = {
+                current: previousStickies.length > 0 ? previousStickies.pop() : null,
+                previous: previousStickies,
+            };
+        }
+        this.setState(newstate);
+    }
+
+    setFullscreen(s) {
+        this.setState({
+            isFullscreen: s,
+        });
+    }
+
+    slideProgress() {
+        let numSlides = this.props.children.length - 1;
+        if (numSlides < 2) {
+            return 100;
+        }
+        return (this.state.currentSlide / numSlides) * 100;
+    }
+
+    render() {
+        this.context.headerCompact = true;
+        this.context.footerVisible = false;
+        let elements = [];
+        if (this.state.stickied.current) {
+            elements.push(
+                <div className="slide sticky" key="sticky">
+                    {this.props.children[this.state.stickied.current]}
+                </div>
+            );
+        }
+        elements.push(
+            <div
+                className={`slide primary ${this.state.stickied.current ? "sticky-is-present" : ""
+                    }`}
+                key="currentSlide"
             >
-              {slideSelect}
-            </Select>
-          </div>
-          <div className="control-options">
-            <Fullscreen
-              className="slide-deck-control-btn"
-              onClick={() => {
-                this.setFullscreen(true);
-              }}
-            ></Fullscreen>
-          </div>
-          <Divider orientation="vertical"></Divider>
-          <div className="control-feedback">
-            <LinearProgress
-              className="slide-deck-progress"
-              variant="determinate"
-              value={progress}
-            ></LinearProgress>
-          </div>
-        </Container>
-      </div>
-    );
-  }
+                {this.props.children[this.state.currentSlide]}
+            </div>
+        );
+        let progress = this.slideProgress();
+        let slideSelect = [];
+        for (let i = 0; i < this.props.children.length; i++) {
+            slideSelect.push(
+                <MenuItem key={i} value={i}>{`Slide ${i + 1}`}</MenuItem>
+            );
+        }
+        let fullscreenClass = this.state.isFullscreen
+            ? "slide-deck-fullscreen"
+            : "";
+        return (
+            <div
+                className={`slide-deck ${fullscreenClass}`}
+                onClick={this.nextSlide}
+                onContextMenu={e => {
+                    e.preventDefault();
+                    this.prevSlide(e);
+                }}
+            >
+                {elements}
+                <Container className={`slide-deck-controls ${fullscreenClass}`}>
+                    <div className="control-slide">
+                        <KeyboardArrowLeft
+                            className="slide-deck-control-btn"
+                            onClick={this.prevSlide}
+                        ></KeyboardArrowLeft>
+                        <KeyboardArrowRight
+                            className="slide-deck-control-btn"
+                            onClick={this.nextSlide}
+                        ></KeyboardArrowRight>
+                        <InputLabel id="slide-deck-selector"></InputLabel>
+                        <Select
+                            className="slide-deck-selector"
+                            labelId="slide-deck-selector"
+                            value={this.state.currentSlide}
+                            onChange={this.handleSlideChange}
+                        >
+                            {slideSelect}
+                        </Select>
+                    </div>
+                    <div className="control-options">
+                        <Fullscreen
+                            className="slide-deck-control-btn"
+                            onClick={e => {
+                                e.stopPropagation();
+                                this.setFullscreen(true);
+                            }}
+                        ></Fullscreen>
+                    </div>
+                    <Divider orientation="vertical"></Divider>
+                    <div className="control-feedback">
+                        <LinearProgress
+                            className="slide-deck-progress"
+                            variant="determinate"
+                            value={progress}
+                        ></LinearProgress>
+                    </div>
+                </Container>
+            </div>
+        );
+    }
 }
 
 export { SlideDeck, Slide };

--- a/src/components/SlideDeck/SlideDeck.js
+++ b/src/components/SlideDeck/SlideDeck.js
@@ -95,8 +95,7 @@ class SlideDeck extends React.Component {
         }
     }
 
-    nextSlide(e) {
-        e.stopPropagation();
+    nextSlide() {
         let next = this.state.currentSlide + 1;
         if (next > this.props.children.length - 1) {
             return;
@@ -126,8 +125,7 @@ class SlideDeck extends React.Component {
         this.setState(newstate);
     }
 
-    prevSlide(e) {
-        e.stopPropagation();
+    prevSlide() {
         let prev = this.state.currentSlide - 1;
         if (prev < 0) {
             return;
@@ -189,10 +187,10 @@ class SlideDeck extends React.Component {
         return (
             <div
                 className={`slide-deck ${fullscreenClass}`}
-                onClick={this.nextSlide}
+                onClick={this.nextSlide()}
                 onContextMenu={e => {
                     e.preventDefault();
-                    this.prevSlide(e);
+                    this.prevSlide();
                 }}
             >
                 {elements}
@@ -200,11 +198,17 @@ class SlideDeck extends React.Component {
                     <div className="control-slide">
                         <KeyboardArrowLeft
                             className="slide-deck-control-btn"
-                            onClick={this.prevSlide}
+                            onClick={e => {
+                                e.stopPropagation();
+                                this.prevSlide()
+                            }}
                         ></KeyboardArrowLeft>
                         <KeyboardArrowRight
                             className="slide-deck-control-btn"
-                            onClick={this.nextSlide}
+                            onClick={e => {
+                                e.stopPropagation();
+                                this.nextSlide()
+                            }}
                         ></KeyboardArrowRight>
                         <InputLabel id="slide-deck-selector"></InputLabel>
                         <Select

--- a/src/components/SlideDeck/SlideDeck.js
+++ b/src/components/SlideDeck/SlideDeck.js
@@ -1,124 +1,229 @@
-import React from "react";
-import PropTypes from "prop-types";
-import { Container } from "@material-ui/core";
-import "./SlideDeck.scss";
-import { UxContext } from "../../contexts.js";
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  Container,
+  Divider,
+  InputLabel,
+  MenuItem,
+  Select,
+  LinearProgress,
+} from '@material-ui/core';
+import './SlideDeck.scss';
+import { UxContext } from '../../contexts.js';
+import {
+  Fullscreen,
+  KeyboardArrowLeft,
+  KeyboardArrowRight,
+} from '@material-ui/icons';
 
 class Slide extends React.Component {
-    static propTypes = {
-        sticky: PropTypes.bool,
-        stickyUntil: PropTypes.number,
-    }
+  static propTypes = {
+    sticky: PropTypes.bool,
+    stickyUntil: PropTypes.number,
+  };
 
-    constructor(props){
-        super(props);
-        this.props = props;
-    }
-    render() {
-        return <Container className={`slide-content ${this.props.className}`}>{this.props.children}</Container>;
-    }
+  constructor(props) {
+    super(props);
+    this.props = props;
+  }
+  render() {
+    return (
+      <Container className={`slide-content ${this.props.className}`}>
+        {this.props.children}
+      </Container>
+    );
+  }
 }
 
 class InvalidChildComponentError extends TypeError {}
 
 class SlideDeck extends React.Component {
-    static contextType = UxContext;
+  static contextType = UxContext;
 
-    constructor(props){
-        super(props);
-        this.state = {
-            currentSlide: 0,
-            stickied: {
-                current: null,
-                previous: [],
-            },
-         };
+  constructor(props) {
+    super(props);
+    this.state = {
+      currentSlide: 0,
+      isFullscreen: false,
+      stickied: {
+        current: null,
+        previous: [],
+      },
+    };
 
-        this.props.children.forEach(child => {
-            if(child.type.name !== "Slide" && process.env.NODE_ENV !== "production"){
-                throw new InvalidChildComponentError(`All children of SlideDeck must be Slide components. Got "${child.type.name}" instead`);
-            }
-        })
-
-        this.handleClick = this.handleClick.bind(this);
-        this.handleOnContext = this.handleOnContext.bind(this);
-    }
-
-    nextSlide() {
-        let next = this.state.currentSlide + 1;
-        if (next > this.props.children.length - 1){
-            return;
-        }
-        let newstate = { currentSlide: next };
-        if (this.props.children[this.state.currentSlide].props.sticky) {
-            let previousStickies = this.state.stickied.previous;
-            if (this.state.stickied.current) {
-                previousStickies.push(this.state.stickied.current);
-            }
-            newstate.stickied = {
-                current: this.state.currentSlide,
-                previous: previousStickies,
-            }
-        }
-        else if (this.state.stickied.current && newstate.currentSlide >= this.props.children[this.state.stickied.current].props.stickyUntil) {
-            let previousStickies = this.state.stickied.previous;
-            previousStickies.push(this.state.stickied.current);
-            newstate.stickied = {
-                current: null,
-                previous: previousStickies,
-            }
-        }
-        this.setState(newstate);
-    }
-
-    prevSlide(){
-        let prev = this.state.currentSlide - 1;
-        if (prev < 0){
-            return;
-        }
-        let newstate = { currentSlide: prev };
-        if (prev === this.state.stickied.current) {
-            let previousStickies = this.state.stickied.previous;
-            newstate.stickied = {
-                current: previousStickies.length > 0 ? previousStickies.pop() : null,
-                previous: previousStickies,
-            }
-        }
-        this.setState(newstate);
-    }
-
-
-    handleClick() {
-        this.nextSlide();
-    }
-
-    handleOnContext(e){
-        e.preventDefault();
-        this.prevSlide();
-    }
-
-    render() {
-        this.context.headerCompact = true;
-        this.context.footerVisible = false;
-        let elements = [];
-        if (this.state.stickied.current) {
-            elements.push(
-                <div className="slide sticky" key="sticky">
-                    {this.props.children[this.state.stickied.current]}
-                </div>
-            );
-        }
-        elements.push(
-            <div className={`slide primary ${this.state.stickied.current ? "sticky-is-present" : ""}`} key="currentSlide">
-                {this.props.children[this.state.currentSlide]}
-            </div>
+    this.props.children.forEach((child) => {
+      if (
+        child.type.name !== 'Slide' &&
+        process.env.NODE_ENV !== 'production'
+      ) {
+        throw new InvalidChildComponentError(
+          `All children of SlideDeck must be Slide components. Got "${child.type.name}" instead`
         );
-        return (
-            <div className="slide-deck" onClick={this.handleClick} onContextMenu={this.handleOnContext}>
-                {elements}
-            </div>
-        );
+      }
+    });
+
+    this.nextSlide = this.nextSlide.bind(this);
+    this.prevSlide = this.prevSlide.bind(this);
+    this.handleSlideChange = this.handleSlideChange.bind(this);
+    this.handleKeyPress = this.handleKeyPress.bind(this);
+  }
+
+  componentDidMount() {
+    document.addEventListener('keydown', this.handleKeyPress, false);
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('keydown', this.handleKeyPress, false);
+  }
+
+  handleSlideChange(e) {
+    this.setState({
+      currentSlide: e.target.value,
+    });
+  }
+
+  handleKeyPress(e) {
+    if (e.key === 'Escape') {
+      this.setState({
+        isFullscreen: false,
+      });
     }
+  }
+
+  nextSlide() {
+    let next = this.state.currentSlide + 1;
+    if (next > this.props.children.length - 1) {
+      return;
+    }
+    let newstate = { currentSlide: next };
+    if (this.props.children[this.state.currentSlide].props.sticky) {
+      let previousStickies = this.state.stickied.previous;
+      if (this.state.stickied.current) {
+        previousStickies.push(this.state.stickied.current);
+      }
+      newstate.stickied = {
+        current: this.state.currentSlide,
+        previous: previousStickies,
+      };
+    } else if (
+      this.state.stickied.current &&
+      newstate.currentSlide >=
+        this.props.children[this.state.stickied.current].props.stickyUntil
+    ) {
+      let previousStickies = this.state.stickied.previous;
+      previousStickies.push(this.state.stickied.current);
+      newstate.stickied = {
+        current: null,
+        previous: previousStickies,
+      };
+    }
+    this.setState(newstate);
+  }
+
+  prevSlide() {
+    let prev = this.state.currentSlide - 1;
+    if (prev < 0) {
+      return;
+    }
+    let newstate = { currentSlide: prev };
+    if (prev === this.state.stickied.current) {
+      let previousStickies = this.state.stickied.previous;
+      newstate.stickied = {
+        current: previousStickies.length > 0 ? previousStickies.pop() : null,
+        previous: previousStickies,
+      };
+    }
+    this.setState(newstate);
+  }
+
+  setFullscreen(s) {
+    this.setState({
+      isFullscreen: s,
+    });
+  }
+
+  slideProgress() {
+    let numSlides = this.props.children.length - 1;
+    if (numSlides < 2) {
+      return 100;
+    }
+    return (this.state.currentSlide / numSlides) * 100;
+  }
+
+  render() {
+    this.context.headerCompact = true;
+    this.context.footerVisible = false;
+    let elements = [];
+    if (this.state.stickied.current) {
+      elements.push(
+        <div className="slide sticky" key="sticky">
+          {this.props.children[this.state.stickied.current]}
+        </div>
+      );
+    }
+    elements.push(
+      <div
+        className={`slide primary ${
+          this.state.stickied.current ? 'sticky-is-present' : ''
+        }`}
+        key="currentSlide"
+      >
+        {this.props.children[this.state.currentSlide]}
+      </div>
+    );
+    let progress = this.slideProgress();
+    let slideSelect = [];
+    for (let i = 0; i < this.props.children.length; i++) {
+      slideSelect.push(
+        <MenuItem key={i} value={i}>{`Slide ${i + 1}`}</MenuItem>
+      );
+    }
+    let fullscreenClass = this.state.isFullscreen
+      ? 'slide-deck-fullscreen'
+      : '';
+    return (
+      <div className={`slide-deck ${fullscreenClass}`}>
+        {elements}
+        <Container className={`slide-deck-controls ${fullscreenClass}`}>
+          <div className="control-slide">
+            <KeyboardArrowLeft
+              className="slide-deck-control-btn"
+              onClick={this.prevSlide}
+            ></KeyboardArrowLeft>
+            <KeyboardArrowRight
+              className="slide-deck-control-btn"
+              onClick={this.nextSlide}
+            ></KeyboardArrowRight>
+            <InputLabel id="slide-deck-selector"></InputLabel>
+            <Select
+              className="slide-deck-selector"
+              labelId="slide-deck-selector"
+              value={this.state.currentSlide}
+              onChange={this.handleSlideChange}
+            >
+              {slideSelect}
+            </Select>
+          </div>
+          <div className="control-options">
+            <Fullscreen
+              className="slide-deck-control-btn"
+              onClick={() => {
+                this.setFullscreen(true);
+              }}
+            ></Fullscreen>
+          </div>
+          <Divider orientation="vertical"></Divider>
+          <div className="control-feedback">
+            <LinearProgress
+              className="slide-deck-progress"
+              variant="determinate"
+              value={progress}
+            ></LinearProgress>
+          </div>
+        </Container>
+      </div>
+    );
+  }
 }
 
-export {SlideDeck, Slide}
+export { SlideDeck, Slide };

--- a/src/components/SlideDeck/SlideDeck.js
+++ b/src/components/SlideDeck/SlideDeck.js
@@ -172,8 +172,7 @@ class SlideDeck extends React.Component {
         }
         elements.push(
             <div
-                className={`slide primary ${this.state.stickied.current ? "sticky-is-present" : ""
-                    }`}
+                className={`slide primary ${this.state.stickied.current ? "sticky-is-present" : ""}`}
                 key="currentSlide"
             >
                 {this.props.children[this.state.currentSlide]}

--- a/src/components/SlideDeck/SlideDeck.scss
+++ b/src/components/SlideDeck/SlideDeck.scss
@@ -1,16 +1,82 @@
 @import "../../variables.scss";
 
+$slide-control-btn-hover: rgba(211, 211, 211, 0.15);
+
 .slide-deck {
     display: grid;
     height: 90vh;
     width: 100%;
     grid-template-columns: 500px auto;
     column-gap: 10px;
+    
+    &.slide-deck-fullscreen {
+        height: 100vh;
+    }
+    
+    .slide-deck-controls {
+        align-items: center;
+        background: darken(gray, 30%);
+        bottom: 1rem;
+        display: flex;
+        height: 4rem;
+        left: 0.5rem;
+        position: fixed;
+        transition: 0.3s;
+        width: 60%;
+        
+        &.slide-deck-fullscreen {
+            opacity: 0;
+        }
+        
+        .control-slide, .control-options, .control-feedback {
+            align-items: center;
+            display: flex;
+            height: 100%;
+            justify-content: center;
+        }
+        
+        .control-slide {
+            justify-content: space-around;
+            width: 35%;
+        }
+        
+        .control-options {
+            width: 20%;
+        }
+        
+        .control-feedback {
+            width: 45%;
+        }
+        
+        .slide-deck-control-btn {
+            border-radius: 50%;
+            cursor: pointer;
+            font-size: 42px;
+            padding: 0.1rem;
+            transition: 0.2s;
+            
+            &:hover {
+                background: $slide-control-btn-hover;    
+            }
+            
+            &:active {
+                background: darken($slide-control-btn-hover, 40%);
+            }
+        }
+        
+        .slide-deck-selector {
+            min-width: 120px;
+        }
+        
+        .slide-deck-progress {
+            width: 90%;
+            margin: 0 auto;
+        }
+    }
 }
 
 .slide {
     display: grid;
-    border: 1px solid $primary-color;
     height: 100%;
     grid-column-start: span 2;
 

--- a/src/components/SlideDeck/SlideDeck.scss
+++ b/src/components/SlideDeck/SlideDeck.scss
@@ -80,6 +80,7 @@ $slide-control-btn-hover: rgba(211, 211, 211, 0.15);
     display: grid;
     height: 100%;
     grid-column-start: span 2;
+    overflow: hidden;
 
     &.sticky-is-present {
         grid-column-start: 2;
@@ -90,8 +91,4 @@ $slide-control-btn-hover: rgba(211, 211, 211, 0.15);
     }
 
     font-size: 20px;
-}
-
-body {
-    overflow: hidden;
 }

--- a/src/components/SlideDeck/SlideDeck.scss
+++ b/src/components/SlideDeck/SlideDeck.scss
@@ -26,6 +26,7 @@ $slide-control-btn-hover: rgba(211, 211, 211, 0.15);
         
         &.slide-deck-fullscreen {
             opacity: 0;
+            bottom: -5rem;
         }
         
         .control-slide, .control-options, .control-feedback {


### PR DESCRIPTION
Closes #154.

Slide deck controls replaced the left/right click to change slides in the slide demo.
The following functionality was implemented:
- Slide pagination using left/right icons or arrow keys
- Fullscreen using an icon (exit using `Escape`)
- Jump to slide using a select menu
- Visual bar showing presentation progress

I think some things, perhaps from lack of React understanding, I implemented in a silly way. For example, having to use `this.<method>.bind(this)` pattern in the constructor seems very redundant.

Additionally, the functionality for sticky slides is not supported in going back to previous/jumping to slides. If React has some form of `refs` as in Vue, this system should be easy to fix.