### PR TITLE
Render list of articles for better discovery

### DIFF
--- a/src/components/ArticleList/ArticleList.js
+++ b/src/components/ArticleList/ArticleList.js
@@ -1,0 +1,35 @@
+import React, { Component } from 'react';
+import { List, ListItem, Link } from '@material-ui/core';
+import ROUTES from '../../Router';
+
+import './ArticleList.scss';
+
+function collateArticles() {
+  // Articles have a title and a source to be used in the Article view
+  let articles = ROUTES.filter((x) => {
+    return x.hasOwnProperty('articleProps') && !!x.articleProps;
+  }).map((x) => (
+    <ListItem>
+      <Link href={x.articleProps.source}>{x.articleProps.title}</Link>
+    </ListItem>
+  ));
+  return articles;
+}
+
+export default class ArticleList extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      articles: collateArticles(),
+    };
+  }
+
+  render() {
+    return (
+      <div className="article-list">
+        <h1>Read Our Articles</h1>
+        <List>{this.state.articles}</List>
+      </div>
+    );
+  }
+}

--- a/src/components/ArticleList/ArticleList.js
+++ b/src/components/ArticleList/ArticleList.js
@@ -10,7 +10,7 @@ function collateArticles() {
     return x.hasOwnProperty('articleProps') && !!x.articleProps;
   }).map((x) => (
     <ListItem>
-      <Link href={x.articleProps.source}>{x.articleProps.title}</Link>
+      <Link href={x.path}>{x.articleProps.title}</Link>
     </ListItem>
   ));
   return articles;

--- a/src/components/ArticleList/ArticleList.scss
+++ b/src/components/ArticleList/ArticleList.scss
@@ -1,0 +1,5 @@
+.article-list {
+    max-height: 40vh;
+    overflow-y: scroll;
+    padding: 2rem;
+}

--- a/src/views/Home/Home.js
+++ b/src/views/Home/Home.js
@@ -1,33 +1,36 @@
-import React from "react";
-import { Box, Container, Grid } from "@material-ui/core";
-import "./Home.scss";
-import DocumentTitle from "../../components/DocumentTitle/DocumentTitle.js";
-import EventBanner from "../../components/EventBanner/EventBanner.jsx"
-import EVENTS from "./Events.js"
-import Logo from "../../components/Logo/Logo.jsx";
+import React from 'react';
+import { Box, Container, Grid } from '@material-ui/core';
+import './Home.scss';
+import ArticleList from '../../components/ArticleList/ArticleList.js';
+import DocumentTitle from '../../components/DocumentTitle/DocumentTitle.js';
+import EventBanner from '../../components/EventBanner/EventBanner.jsx';
+import EVENTS from './Events.js';
+import Logo from '../../components/Logo/Logo.jsx';
 
 export default function HomeView() {
-	return (
-		<Box>
-			<DocumentTitle title="" />
-			<Grid container direction="column" justify="center" alignItems="center" className="hero">
-				<Grid item>
-					<Logo animate="true" className="logo" />
-				</Grid>
-				<Grid item>
-					<span>Software Engineering Club</span>
-				</Grid>
-			</Grid>
-			<Container className="banners">
-				{EVENTS.map((event, index) => {
-					return (
-						<EventBanner
-						key={"eventBanner-" + index}
-						{...event}
-						/>
-					)
-				})}
-			</Container>
-		</Box>
-	)
+  return (
+    <Box>
+      <DocumentTitle title="" />
+      <Grid
+        container
+        direction="column"
+        justify="center"
+        alignItems="center"
+        className="hero"
+      >
+        <Grid item>
+          <Logo animate="true" className="logo" />
+        </Grid>
+        <Grid item>
+          <span>Software Engineering Club</span>
+        </Grid>
+      </Grid>
+      <Container className="banners">
+        {EVENTS.map((event, index) => {
+          return <EventBanner key={'eventBanner-' + index} {...event} />;
+        })}
+      </Container>
+      <ArticleList></ArticleList>
+    </Box>
+  );
 }


### PR DESCRIPTION
Articles are now collected based on the properties found in `Router.js`. Each link that has defined `articleProps` is considered a link to an article. It is rendered in a scrollable list. This PR adds minimal styling and includes it on the home page as a proof of concept.

PoC for #189

![image](https://user-images.githubusercontent.com/19696846/95004371-48e4af00-05b8-11eb-8464-314bd3c87e0d.png)

closes #189